### PR TITLE
Add async retry logic and error notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.mypy_cache/
+.ruff_cache/

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+ignore_missing_imports = True
+exclude = tests/

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -9,7 +9,7 @@ from main import SafetyChecker
 
 @pytest.mark.asyncio
 async def test_is_safe(monkeypatch):
-    sc = SafetyChecker(None)
+    sc = SafetyChecker(None, None)
 
     async def ok(_):
         return True


### PR DESCRIPTION
## Summary
- implement generic `retry` helper with timeout and notifier
- wrap gmgn, Solscan, Pyth, and Jupiter HTTP calls in retry logic
- propagate Solscan and websocket errors to notifier
- reconnect websocket on disconnect
- add mypy configuration and ignore caches

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`
