### PR TITLE
Implement trade count weighting for Kelly sizing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ graph TD
 
 | Path        | Class / Fn                   | Public API                   | Unit‑tests             |
 | ----------- | ---------------------------- | ---------------------------- | ---------------------- |
-| `wallet.py` | `WalletAnalyzer`             | `strong(addrs)` → List\[str] | `tests/test_wallet.py` |
+| `wallet.py` | `WalletAnalyzer`             | `strong(addrs)` → List\[WalletMetrics] | `tests/test_wallet.py` |
 | `safety.py` | `SafetyChecker`              | `is_safe(mint)` → bool       | fuzz via Hypothesis    |
 | `sizing.py` | `kelly_size(nav, edge, vol)` | returns stake value          | deterministic tests    |
 | `exec.py`   | `JupiterExec`                | `quote()`, `swap_tx()`       | mocked HTTP            |

--- a/exec.py
+++ b/exec.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import aiohttp
-import base64
 from typing import Any
 
 from config import JUPITER_URL

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import logging.config
+from pythonjsonlogger import jsonlogger
 
 from config import PRIV_KEY
 from gmgn_wallet_bot import main
@@ -28,8 +29,6 @@ class SecretFilter(logging.Filter):
             record.args = ()
         return True
 
-
-from pythonjsonlogger import jsonlogger
 
 LOG_CONFIG = {
     "version": 1,

--- a/tests/test_kelly.py
+++ b/tests/test_kelly.py
@@ -14,3 +14,9 @@ def test_kelly_monotonic():
 
 def test_kelly_negative():
     assert kelly_size(100, -0.1, 0.1, 10) == 0
+
+
+def test_kelly_trade_n_scaling():
+    large = kelly_size(1000, 1.0, 1.0, 30)
+    small = kelly_size(1000, 1.0, 1.0, 5)
+    assert small < large

--- a/tests/test_priority_fee.py
+++ b/tests/test_priority_fee.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import conftest  # noqa:F401
-import asyncio
 import pytest
 from exec import get_priority_fee
 

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -15,7 +15,7 @@ async def test_size_basic(monkeypatch):
         return 0.1
 
     monkeypatch.setattr("engine.pyth_atr", atr)
-    size = await eng._size("TOKEN", 1.0, 100.0)
+    size = await eng._size("TOKEN", 1.0, 100.0, 30)
     assert size == pytest.approx(25.0)
 
 
@@ -27,5 +27,18 @@ async def test_size_negative_sharpe(monkeypatch):
         return 0.1
 
     monkeypatch.setattr("engine.pyth_atr", atr)
-    size = await eng._size("TOKEN", -1.0, 100.0)
+    size = await eng._size("TOKEN", -1.0, 100.0, 30)
     assert size == 0
+
+
+@pytest.mark.asyncio
+async def test_size_trade_n(monkeypatch):
+    eng = CopyEngine([])
+
+    async def atr(*a, **k):
+        return 1.0
+
+    monkeypatch.setattr("engine.pyth_atr", atr)
+    big = await eng._size("TOKEN", 0.5, 100.0, 30)
+    small = await eng._size("TOKEN", 0.5, 100.0, 5)
+    assert small < big

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -18,4 +18,4 @@ async def test_strong(monkeypatch):
 
     monkeypatch.setattr(wa, "_one", fake_one)
     res = await wa.strong(["A", "B"])
-    assert res == ["A"]
+    assert res == [WalletMetrics("A", 1.5, 10.0, 0.6, 5)]

--- a/wallet.py
+++ b/wallet.py
@@ -97,6 +97,7 @@ class WalletAnalyzer:
             len(trades),
         )
 
-    async def strong(self, addrs: List[str]):
+    async def strong(self, addrs: List[str]) -> List[WalletMetrics]:
+        """Return metrics for wallets that meet strength criteria."""
         res = await asyncio.gather(*(self._one(a) for a in addrs))
-        return [m.address for m in res if m and m.is_strong()]
+        return [m for m in res if m and m.is_strong()]


### PR DESCRIPTION
## Summary
- return `WalletMetrics` from `WalletAnalyzer.strong`
- store wallet metrics in `CopyEngine` and use them when sizing
- scale `_size` by the wallet's trade count
- adjust ruff issues and update docs
- update and expand tests

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`