### PR TITLE
Implement correlation-cluster pruning

### DIFF
--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -13,9 +13,48 @@ async def test_strong(monkeypatch):
 
     async def fake_one(addr: str):
         if addr == "A":
-            return WalletMetrics(addr, 1.5, 10.0, 0.6, 5)
-        return WalletMetrics(addr, 0.5, -1.0, 0.4, 2)
+            return WalletMetrics(
+                addr, 1.5, 10.0, 0.6, 5, {"d1": 1, "d2": 1, "d3": 1, "d4": 1, "d5": 1}
+            )
+        return WalletMetrics(addr, 0.5, -1.0, 0.4, 2, {"d1": -1})
 
     monkeypatch.setattr(wa, "_one", fake_one)
     res = await wa.strong(["A", "B"])
     assert res == ["A"]
+
+
+@pytest.mark.asyncio
+async def test_cluster_prune(monkeypatch):
+    wa = WalletAnalyzer()
+
+    async def fake_one(addr: str):
+        if addr == "A":
+            return WalletMetrics(
+                addr,
+                1.6,
+                10.0,
+                0.6,
+                5,
+                {"d1": 1, "d2": 2, "d3": 3, "d4": 4, "d5": 5},
+            )
+        if addr == "B":
+            return WalletMetrics(
+                addr,
+                1.2,
+                9.0,
+                0.6,
+                5,
+                {"d1": 2, "d2": 4, "d3": 6, "d4": 8, "d5": 10},
+            )
+        return WalletMetrics(
+            addr,
+            1.1,
+            8.0,
+            0.6,
+            5,
+            {"d1": -1, "d2": -1, "d3": -1, "d4": -1, "d5": -1},
+        )
+
+    monkeypatch.setattr(wa, "_one", fake_one)
+    res = await wa.strong(["A", "B", "C"])
+    assert set(res) == {"A", "C"}


### PR DESCRIPTION
## Summary
- extend `WalletMetrics` with daily PnL map
- implement `_corr` helper for correlation without numpy
- add networkx based clustering in `WalletAnalyzer.strong`
- test new pruning logic

## Testing
- `ruff check .`
- `black wallet.py tests/test_wallet.py`
- `mypy .`
- `pytest -q`