### PR TITLE
feat: track real slippage

### DIFF
--- a/exec.py
+++ b/exec.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import aiohttp
-import base64
 from typing import Any
 
 from config import JUPITER_URL

--- a/helpers.py
+++ b/helpers.py
@@ -24,3 +24,10 @@ async def retry(
                 raise
             await asyncio.sleep(delay)
             delay = min(delay * 2, 30)
+
+
+def slippage_bps(executed_price: float, quote_price: float) -> float:
+    """Return slippage in basis points given executed and quoted price."""
+    if executed_price <= 0 or quote_price <= 0:
+        return 0.0
+    return abs(executed_price / quote_price - 1) * 10_000

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import logging.config
+from pythonjsonlogger import jsonlogger
 
 from config import PRIV_KEY
 from gmgn_wallet_bot import main
@@ -28,8 +29,6 @@ class SecretFilter(logging.Filter):
             record.args = ()
         return True
 
-
-from pythonjsonlogger import jsonlogger
 
 LOG_CONFIG = {
     "version": 1,

--- a/tests/test_priority_fee.py
+++ b/tests/test_priority_fee.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import conftest  # noqa:F401
-import asyncio
 import pytest
 from exec import get_priority_fee
 

--- a/tests/test_slippage.py
+++ b/tests/test_slippage.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import conftest  # noqa:F401
+from helpers import slippage_bps
+import pytest
+
+
+def test_slippage_basic():
+    assert slippage_bps(1.05, 1.0) == pytest.approx(500.0)
+
+
+def test_slippage_zero():
+    assert slippage_bps(0.0, 1.0) == 0.0


### PR DESCRIPTION
## Summary
- monitor execution quality by calculating real slippage
- expose `slippage_bps` helper
- add basic tests for slippage math
- tidy imports per ruff

## Testing
- `black --check .`
- `ruff check .`
- `mypy --config-file mypy.ini .`
- `pytest -q`