### PR TITLE
Add compute budget limit and Helius header

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -17,3 +17,5 @@ PRUNE_INTERVAL_H=6
 RPC_URL=https://api.mainnet-beta.solana.com
 # Optional Jito RPC endpoint
 JITO_RPC=
+# Optional Helius API key
+HELIUS_API_KEY=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.12-slim
+RUN apt-get update && apt-get install -y build-essential libssl-dev
 WORKDIR /app
 COPY . .
 RUN pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ pip install -r requirements.txt
 ```bash
 cp .env.template .env
 # edit .env and provide PRIVATE_KEY, TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID
+# optional HELIUS_API_KEY for priority fee estimates
 ```
 
 ## Quick Start

--- a/config.py
+++ b/config.py
@@ -17,3 +17,4 @@ PRUNE_INTERVAL_H = float(os.getenv("PRUNE_INTERVAL_H", 6))
 JUPITER_URL = "https://quote-api.jup.ag"
 PYTH_HIST_URL = "https://hermes.pyth.network/api/historical_price/"
 RPC_URL = os.getenv("RPC_URL", "https://api.mainnet-beta.solana.com")
+HELIUS_API_KEY = os.getenv("HELIUS_API_KEY", "")

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import logging.config
+from pythonjsonlogger import jsonlogger
 
 from config import PRIV_KEY
 from gmgn_wallet_bot import main
@@ -28,8 +29,6 @@ class SecretFilter(logging.Filter):
             record.args = ()
         return True
 
-
-from pythonjsonlogger import jsonlogger
 
 LOG_CONFIG = {
     "version": 1,

--- a/tests/test_priority_fee.py
+++ b/tests/test_priority_fee.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import conftest  # noqa:F401
-import asyncio
 import pytest
 from exec import get_priority_fee
 
@@ -15,7 +14,7 @@ class FakeSession:
     async def __aexit__(self, *a):
         pass
 
-    def get(self, url):
+    def get(self, url, *a, **k):
         class Resp:
             async def json(self):
                 return {"priorityFeeEstimate": 42}


### PR DESCRIPTION
## Summary
- set optional HELIUS_API_KEY in config
- include key when calling Helius for priority fee
- insert compute-unit price and limit instructions when mutating swap tx
- extend `.env.template` and docs for the new env var
- install build tools in Dockerfile
- fix lints and tests

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`
