### PR TITLE
Implement priority fee injection

### DIFF
--- a/exec.py
+++ b/exec.py
@@ -57,14 +57,54 @@ class JupiterExec:
 
 
 async def get_priority_fee() -> int:
+    """Return the estimated micro-lamports per compute unit for swaps."""
+
     url = "https://api.helius.xyz/v1/getPriorityFeeEstimate"
     async with aiohttp.ClientSession() as s:
         async with s.get(f"{url}?transaction_type=swap") as r:
+            if r.status == 429:
+                return 1000
             data = await r.json()
             return int(data.get("priorityFeeEstimate", 1000))
 
 
 async def add_priority_fee(tx_bytes: bytes) -> bytes:
-    lamports_per_cu = await get_priority_fee()
-    _ = lamports_per_cu  # placeholder for real mutation
-    return tx_bytes
+    """Inject compute budget instructions into a serialized transaction."""
+
+    from solders.compute_budget import (
+        ID as CB_ID,
+        set_compute_unit_limit,
+        set_compute_unit_price,
+    )
+    from solders.instruction import CompiledInstruction
+    from solders.message import Message
+    from solders.transaction import VersionedTransaction
+
+    fee = await get_priority_fee()
+    tx = VersionedTransaction.from_bytes(tx_bytes)
+
+    account_keys = list(tx.message.account_keys)
+    if CB_ID not in account_keys:
+        account_keys.append(CB_ID)
+        extra_ro = 1
+    else:
+        extra_ro = 0
+    cb_index = account_keys.index(CB_ID)
+
+    price_ix = CompiledInstruction(cb_index, set_compute_unit_price(fee).data, b"")
+    limit_ix = CompiledInstruction(
+        cb_index, set_compute_unit_limit(1_400_000).data, b""
+    )
+
+    new_instructions = [price_ix, limit_ix, *tx.message.instructions]
+    hdr = tx.message.header
+    msg = Message.new_with_compiled_instructions(
+        hdr.num_required_signatures,
+        hdr.num_readonly_signed_accounts,
+        hdr.num_readonly_unsigned_accounts + extra_ro,
+        account_keys,
+        tx.message.recent_blockhash,
+        new_instructions,
+    )
+    new_tx = VersionedTransaction.populate(msg, tx.signatures)
+    return bytes(new_tx)

--- a/tests/test_priority_fee.py
+++ b/tests/test_priority_fee.py
@@ -4,10 +4,16 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import conftest  # noqa:F401
 import pytest
-from exec import get_priority_fee
+from exec import add_priority_fee, get_priority_fee
+
+
+aiohttp = sys.modules["aiohttp"]
 
 
 class FakeSession:
+    def __init__(self, status: int = 200):
+        self.status = status
+
     async def __aenter__(self):
         return self
 
@@ -15,7 +21,12 @@ class FakeSession:
         pass
 
     def get(self, url):
+        status = self.status
+
         class Resp:
+            def __init__(self, status: int):
+                self.status = status
+
             async def json(self):
                 return {"priorityFeeEstimate": 42}
 
@@ -25,14 +36,46 @@ class FakeSession:
             async def __aexit__(self, *a):
                 pass
 
-        return Resp()
-
-
-aiohttp = sys.modules["aiohttp"]
-aiohttp.ClientSession = lambda: FakeSession()
+        return Resp(status)
 
 
 @pytest.mark.asyncio
 async def test_priority_fee():
+    aiohttp.ClientSession = lambda: FakeSession(200)
     fee = await get_priority_fee()
     assert fee == 42
+
+
+@pytest.mark.asyncio
+async def test_priority_fee_fallback():
+    aiohttp.ClientSession = lambda: FakeSession(429)
+    fee = await get_priority_fee()
+    assert fee == 1000
+
+
+@pytest.mark.asyncio
+async def test_add_priority_fee(monkeypatch):
+    async def pf():
+        return 7
+
+    monkeypatch.setattr("exec.get_priority_fee", pf)
+    from solders.hash import Hash
+    from solders.keypair import Keypair
+    from solders.pubkey import Pubkey
+    from solders.instruction import Instruction
+    from solders.message import Message
+    from solders.transaction import VersionedTransaction
+
+    payer = Keypair()
+    ix = Instruction(Pubkey.default(), b"\x01", [])
+    msg = Message.new_with_blockhash([ix], payer.pubkey(), Hash.new_unique())
+    tx = VersionedTransaction(msg, [payer])
+    out = await add_priority_fee(bytes(tx))
+    new_tx = VersionedTransaction.from_bytes(out)
+    assert (
+        str(new_tx.message.program_id(0))
+        == "ComputeBudget111111111111111111111111111111"
+    )
+    assert (
+        new_tx.message.instructions[0].data == b"\x03\x07\x00\x00\x00\x00\x00\x00\x00"
+    )


### PR DESCRIPTION
## Summary
- fetch priority fee estimate with 429 fallback
- insert compute budget instructions in swap transactions
- exercise new behaviour in unit tests

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`
