### PR TITLE
Implement Jito bundle submission

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -159,7 +159,7 @@ class CopyEngine:
         try:
             start_t = time.time()
             if JITO_RPC:
-                ok = await send_bundle(tx.serialize())
+                ok = await send_bundle(base64.b64encode(tx.serialize()).decode())
                 if ok:
                     sig = "bundle"
                 else:

--- a/mev.py
+++ b/mev.py
@@ -1,18 +1,17 @@
 import aiohttp
-import base64
 
 from config import JITO_RPC
 
 
-async def send_bundle(tx_bytes: bytes) -> bool:
-    """Submit a signed transaction to the Jito block engine.
+async def send_bundle(tx_b64: str) -> bool:
+    """Submit a base64-encoded transaction to the Jito block engine.
 
     Returns ``True`` on HTTP 200, otherwise ``False``.
     """
     async with aiohttp.ClientSession() as s:
         async with s.post(
             JITO_RPC or "https://block-engine.jito.wtf/api/v1/transactions",
-            json={"transaction": base64.b64encode(tx_bytes).decode()},
+            json={"transaction": tx_b64},
             timeout=aiohttp.ClientTimeout(total=10),
         ) as r:
             return r.status == 200

--- a/tests/test_engine_mev.py
+++ b/tests/test_engine_mev.py
@@ -1,0 +1,86 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import conftest  # noqa:F401
+import pytest
+from engine import CopyEngine
+import types
+
+
+class DummyExec:
+    async def quote(self, *a, **k):
+        return {"data": [0]}
+
+    async def swap_tx(self, *a, **k):
+        import base64
+
+        return base64.b64encode(b"abc").decode()
+
+
+@pytest.mark.asyncio
+async def test_jito_fallback(monkeypatch):
+    eng = CopyEngine([])
+    eng.exec = DummyExec()
+    monkeypatch.setattr("engine.JITO_RPC", "url")
+    monkeypatch.setattr(
+        "engine.SLIPPAGE_G", types.SimpleNamespace(observe=lambda *a, **k: None)
+    )
+    monkeypatch.setattr(
+        "engine.INCLUSION_G", types.SimpleNamespace(observe=lambda *a, **k: None)
+    )
+
+    async def dummy_size(*a, **k):
+        return 1.0
+
+    monkeypatch.setattr(eng, "_size", dummy_size)
+
+    async def dummy_pf(b):
+        return b
+
+    monkeypatch.setattr("engine.add_priority_fee", dummy_pf)
+    monkeypatch.setattr("engine.base58.b58decode", lambda b: b"")
+
+    class Tx:
+        def sign(self, *a):
+            pass
+
+        def serialize(self):
+            return b"tx_signed"
+
+    monkeypatch.setattr("engine.Transaction.deserialize", lambda b: Tx())
+    monkeypatch.setattr("engine.Keypair.from_secret_key", lambda b: object())
+
+    calls: dict[str, str | bytes] = {}
+
+    async def send_bundle(tx: str) -> bool:
+        calls["bundle"] = tx
+        return False
+
+    monkeypatch.setattr("engine.send_bundle", send_bundle)
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        def send_raw_transaction(self, tx):
+            calls["raw"] = tx
+            return {"result": "sig"}
+
+    monkeypatch.setattr("engine.Client", FakeClient)
+    eng.pb.nav = lambda: 100.0
+    eng.pb.pos = {}
+    eng.pb.mark = {}
+    eng.pb.update = lambda *a, **k: None
+    eng.pb.update_peak = lambda *a, **k: None
+    eng.pb.global_dd = lambda x: 0.0
+
+    async def dummy_send(*a, **k):
+        return None
+
+    eng.notif.send = dummy_send
+
+    await eng._execute_buy({"token": "ABC", "price": "1"})
+
+    assert calls["bundle"] == "dHhfc2lnbmVk"
+    assert calls["raw"] == b"tx_signed"

--- a/tests/test_mev.py
+++ b/tests/test_mev.py
@@ -38,10 +38,10 @@ aiohttp = sys.modules["aiohttp"]
 @pytest.mark.asyncio
 async def test_send_bundle_success(monkeypatch):
     monkeypatch.setattr(aiohttp, "ClientSession", lambda: FakeSession(200))
-    assert await send_bundle(b"tx")
+    assert await send_bundle("dHg=")
 
 
 @pytest.mark.asyncio
 async def test_send_bundle_fail(monkeypatch):
     monkeypatch.setattr(aiohttp, "ClientSession", lambda: FakeSession(500))
-    assert not await send_bundle(b"tx")
+    assert not await send_bundle("dHg=")


### PR DESCRIPTION
## Summary
- submit swaps to Jito via new `send_bundle()` API
- fallback to raw transaction if bundle submission fails
- add regression test for bundle fallback
- adjust MEV unit tests for string input

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`