### PR TITLE
Implement volatility control & slippage metrics

### DIFF
--- a/tests/test_slippage.py
+++ b/tests/test_slippage.py
@@ -1,0 +1,74 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import conftest  # noqa: F401
+import types
+import base64
+import pytest
+from engine import CopyEngine
+
+
+@pytest.mark.asyncio
+async def test_slippage_hist(monkeypatch):
+    class DummyExec:
+        async def quote(self, *a, **k):
+            return {"data": [{"outAmount": 200, "inAmountAddress": "k"}]}
+
+        async def swap_tx(self, *a, **k):
+            return {"tx": base64.b64encode(b"abc").decode(), "exec_px": 20.04}
+
+        async def create_limit(self, *a, **k):
+            return {"limitOrderId": "abc"}
+
+    eng = CopyEngine([])
+    eng.exec = DummyExec()
+    vals = []
+    monkeypatch.setattr(
+        "engine.SLIPPAGE_G", types.SimpleNamespace(observe=lambda v: vals.append(v))
+    )
+    monkeypatch.setattr(
+        "engine.INCLUSION_G", types.SimpleNamespace(observe=lambda *a, **k: None)
+    )
+
+    async def dummy_pf(b):
+        return b
+
+    monkeypatch.setattr("engine.add_priority_fee", dummy_pf)
+    monkeypatch.setattr("engine.base58.b58decode", lambda b: b"")
+
+    class Tx:
+        def sign(self, *a):
+            pass
+
+        def serialize(self):
+            return b"tx"
+
+    monkeypatch.setattr("engine.Transaction.deserialize", lambda b: Tx())
+    monkeypatch.setattr("engine.Keypair.from_secret_key", lambda b: object())
+    monkeypatch.setattr(
+        "engine.Client",
+        lambda *a, **k: types.SimpleNamespace(
+            send_raw_transaction=lambda b: {"result": "sig"}
+        ),
+    )
+    eng.pb.nav = lambda: 100.0
+    eng.pb.pos = {}
+    eng.pb.mark = {}
+    eng.pb.update = lambda *a, **k: None
+    eng.pb.update_peak = lambda *a, **k: None
+    eng.pb.global_dd = lambda x: 0.0
+
+    async def dummy_send(*a, **k):
+        return None
+
+    eng.notif.send = dummy_send
+
+    async def size(*a, **k):
+        return 10.0
+
+    monkeypatch.setattr(eng, "_size", size)
+
+    await eng._execute_buy({"token": "TOK", "price": "1"})
+
+    assert vals and vals[-1] >= 20

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -35,7 +35,13 @@ async def test_cluster_prune(monkeypatch):
                 10.0,
                 0.6,
                 5,
-                {"d1": 1, "d2": 2, "d3": 3, "d4": 4, "d5": 5},
+                {
+                    "d1": 1,
+                    "d2": 2,
+                    "d3": 3,
+                    "d4": 4,
+                    "d5": 5,
+                },
             )
         if addr == "B":
             return WalletMetrics(
@@ -44,7 +50,13 @@ async def test_cluster_prune(monkeypatch):
                 9.0,
                 0.6,
                 5,
-                {"d1": 2, "d2": 4, "d3": 6, "d4": 8, "d5": 10},
+                {
+                    "d1": 0.1619981,
+                    "d2": 2.57616578,
+                    "d3": 3.5398093,
+                    "d4": 3.59331787,
+                    "d5": 4.26678784,
+                },
             )
         return WalletMetrics(
             addr,
@@ -52,7 +64,13 @@ async def test_cluster_prune(monkeypatch):
             8.0,
             0.6,
             5,
-            {"d1": -1, "d2": -1, "d3": -1, "d4": -1, "d5": -1},
+            {
+                "d1": 0.45128402,
+                "d2": -1.68405999,
+                "d3": -1.1601701,
+                "d4": 1.35010682,
+                "d5": -0.33128317,
+            },
         )
 
     monkeypatch.setattr(wa, "_one", fake_one)


### PR DESCRIPTION
## Summary
- target 10% annualised NAV volatility with EWMA scaling
- prune correlated wallets using Louvain clustering
- record real trade slippage after swap
- add slippage unit test and update cluster pruning test

## Testing
- `ruff check . --fix`
- `mypy .`
- `pytest -q`