### PR TITLE
Add paper trading mode and reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: |
+          DRY_RUN=true python main.py run --ws-log tests/fixtures/sample.jsonl &
+          pid=$!
+          sleep 30
+          kill $pid || true
+      - run: test -f journal.csv
+      - run: black --check .
+      - run: ruff .
+      - run: mypy .
+      - run: pytest -q

--- a/config.py
+++ b/config.py
@@ -19,3 +19,5 @@ PYTH_HIST_URL = "https://hermes.pyth.network/api/historical_price/"
 RPC_URL = os.getenv("RPC_URL", "https://api.mainnet-beta.solana.com")
 JITO_RPC = os.getenv("JITO_RPC", "")
 SOL_MINT = "So11111111111111111111111111111111111111112"
+DRY_RUN = os.getenv("DRY_RUN", "false").lower() in {"1", "true", "yes"}
+SIM_SLIPPAGE_BPS = int(os.getenv("SIM_SLIPPAGE_BPS", 10))

--- a/gmgn_wallet_bot.py
+++ b/gmgn_wallet_bot.py
@@ -1,20 +1,21 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Optional
 
 from engine import CopyEngine
 from gmgn import gmgn
 
 
-async def cli() -> None:
+async def run_engine(ws_log: Optional[str] = None, dry_run: bool = False) -> None:
     seed = [w["address"] for w in gmgn().getTrendingWallets()["data"]][:10]
-    eng = CopyEngine(seed)
+    eng = CopyEngine(seed, dry=dry_run, ws_log=ws_log)
     await eng.run()
 
 
-def main() -> None:
+def main(ws_log: Optional[str] = None, dry_run: bool = False) -> None:
     try:
-        asyncio.run(cli())
+        asyncio.run(run_engine(ws_log, dry_run))
     except KeyboardInterrupt:
         pass
 

--- a/helpers.py
+++ b/helpers.py
@@ -24,3 +24,29 @@ async def retry(
                 raise
             await asyncio.sleep(delay)
             delay = min(delay * 2, 30)
+
+
+def calc_report(df):
+    """Return CAGR, Sharpe and max drawdown from a journal DataFrame."""
+    nav = [float(x) for x in df["nav_after"]]
+    ts = [float(x) for x in df["ts"]]
+    if len(nav) < 2:
+        return 0.0, 0.0, 0.0
+    years = (ts[-1] - ts[0]) / 31_536_000 or 1e-9
+    cagr = (nav[-1] / nav[0]) ** (1 / years) - 1
+    rets = [(nav[i] / nav[i - 1]) - 1 for i in range(1, len(nav))]
+    if rets:
+        mean_r = sum(rets) / len(rets)
+        var = sum((r - mean_r) ** 2 for r in rets) / len(rets)
+        sharpe = (mean_r / (var**0.5 or 1e-9)) * (252**0.5)
+    else:
+        sharpe = 0.0
+    peak = nav[0]
+    max_dd = 0.0
+    for v in nav:
+        if v > peak:
+            peak = v
+        dd = 1 - v / peak
+        if dd > max_dd:
+            max_dd = dd
+    return float(cagr), float(sharpe), float(max_dd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,8 +90,28 @@ class Series(list):
     def std(self):
         return 1.0
 
+    def astype(self, t):
+        return Series([t(x) for x in self])
+
+    def to_numpy(self):
+        return self
+
 
 pd_mod.Series = Series
+
+
+class DataFrame(dict):
+    def __init__(self, data):
+        super().__init__(data)
+
+    def __getitem__(self, k):
+        return Series(self.get(k, []))
+
+    def to_numpy(self):
+        return list(self.values())
+
+
+pd_mod.DataFrame = DataFrame
 sys.modules.setdefault("pandas", pd_mod)
 
 # Stub dotenv

--- a/tests/fixtures/sample.jsonl
+++ b/tests/fixtures/sample.jsonl
@@ -1,0 +1,1 @@
+{"address":"A","token":"T","side":"buy","price":"1","timestamp":0}

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,72 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import conftest  # noqa:F401
+import types
+import base64
+import pytest
+
+from engine import CopyEngine
+
+
+class DummyExec:
+    async def quote(self, *a, **k):
+        return {"data": [{"outAmount": 100, "inAmountAddress": "k"}]}
+
+    async def swap_tx(self, *a, **k):
+        return {"tx": base64.b64encode(b"abc").decode(), "exec_px": 1.01}
+
+    async def create_limit(self, *a, **k):
+        return {"limitOrderId": "id"}
+
+
+@pytest.mark.asyncio
+async def test_dry_run(monkeypatch, tmp_path):
+    path = tmp_path / "j.csv"
+    eng = CopyEngine([], dry=True, journal_path=str(path))
+    eng.exec = DummyExec()
+    monkeypatch.setattr(
+        "engine.SLIPPAGE_G", types.SimpleNamespace(observe=lambda *a, **k: None)
+    )
+    monkeypatch.setattr(
+        "engine.INCLUSION_G", types.SimpleNamespace(observe=lambda *a, **k: None)
+    )
+    monkeypatch.setattr(
+        "engine.send_bundle", lambda *a, **k: (_ for _ in ()).throw(AssertionError())
+    )
+    monkeypatch.setattr("engine.add_priority_fee", lambda b: b)
+    monkeypatch.setattr("engine.base58.b58decode", lambda b: b"")
+    monkeypatch.setattr(
+        "engine.Transaction.deserialize",
+        lambda b: types.SimpleNamespace(
+            sign=lambda *a, **k: None, serialize=lambda: b"tx"
+        ),
+    )
+    monkeypatch.setattr("engine.Keypair.from_secret_key", lambda b: object())
+    monkeypatch.setattr(
+        "engine.Client",
+        lambda *a, **k: types.SimpleNamespace(
+            send_raw_transaction=lambda *a, **k: (_ for _ in ()).throw(AssertionError())
+        ),
+    )
+    eng.pb.nav = lambda: 100.0
+    eng.pb.pos = {}
+    eng.pb.mark = {}
+    eng.pb.update = lambda *a, **k: None
+    eng.pb.update_peak = lambda *a, **k: None
+    eng.pb.global_dd = lambda x: 0.0
+
+    async def send(*a, **k):
+        return None
+
+    eng.notif.send = send
+
+    async def size(*a, **k):
+        return 10.0
+
+    monkeypatch.setattr(eng, "_size", size)
+
+    sig = await eng._execute_buy({"token": "TOK", "price": "1", "address": "A"})
+    assert sig.startswith("SIM-")
+    assert path.exists() and path.read_text()

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import conftest  # noqa:F401
+import pandas as pd
+from helpers import calc_report
+
+
+def test_calc_report():
+    df = pd.DataFrame(
+        {
+            "ts": [0, 86400],
+            "address": ["a", "a"],
+            "token": ["t", "t"],
+            "side": ["buy", "sell"],
+            "qty": [1, 1],
+            "price": [1, 1],
+            "nav_after": [100, 110],
+        }
+    )
+    cagr, sharpe, dd = calc_report(df)
+    assert cagr > 0
+    assert dd == 0

--- a/tests/test_ws_log.py
+++ b/tests/test_ws_log.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import conftest  # noqa:F401
+import pytest
+
+from engine import CopyEngine
+
+
+@pytest.mark.asyncio
+async def test_ws_log(monkeypatch, tmp_path):
+    log = tmp_path / "log.jsonl"
+    log.write_text(
+        '{"address":"A","token":"T","side":"buy","price":"1","timestamp":0}\n'
+    )
+    eng = CopyEngine(["A"], dry=True, ws_log=str(log))
+    events = []
+
+    async def dummy(ev):
+        events.append(ev)
+
+    monkeypatch.setattr(eng, "_execute_buy", dummy)
+
+    async def safe(*a, **k):
+        return True
+
+    monkeypatch.setattr(eng.safe, "is_safe", safe)
+    await eng._wallet_stream()
+    assert events and events[0]["token"] == "T"


### PR DESCRIPTION
## Summary
- implement dry-run mode flag with simulated slippage
- journal trades to CSV and support log replay
- add report subcommand for CAGR/Sharpe/Max-DD
- provide CI smoke test
- cover new logic with tests

## Testing
- `black -q .`
- `ruff check .`
- `mypy .`
- `pytest -q`