### PR TITLE
Fix Keypair import for solders

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -16,7 +16,7 @@ import aiohttp
 import base58
 import websockets
 from prometheus_client import Gauge, Histogram, start_http_server
-from solana.keypair import Keypair
+from solders.keypair import Keypair
 from solana.rpc.api import Client
 from solana.transaction import Transaction
 
@@ -222,7 +222,7 @@ class CopyEngine:
         if not self.dry:
             tx_bytes = base64.b64decode(tx_b64)
             tx_bytes = await add_priority_fee(tx_bytes)
-            kp = Keypair.from_secret_key(base58.b58decode(PRIV_KEY))
+            kp = Keypair.from_bytes(base58.b58decode(PRIV_KEY))
             tx = Transaction.deserialize(tx_bytes)
             tx.sign(kp)
             client = Client(RPC_URL)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ gmgn-wrapper
 python-dotenv
 prometheus-client
 solana
+solders
 numpy
 scikit-learn
 python-json-logger

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -43,7 +43,7 @@ async def test_dry_run(monkeypatch, tmp_path):
             sign=lambda *a, **k: None, serialize=lambda: b"tx"
         ),
     )
-    monkeypatch.setattr("engine.Keypair.from_secret_key", lambda b: object())
+    monkeypatch.setattr("engine.Keypair.from_bytes", lambda b: object())
     monkeypatch.setattr(
         "engine.Client",
         lambda *a, **k: types.SimpleNamespace(

--- a/tests/test_engine_mev.py
+++ b/tests/test_engine_mev.py
@@ -49,7 +49,7 @@ async def test_jito_fallback(monkeypatch):
             return b"tx_signed"
 
     monkeypatch.setattr("engine.Transaction.deserialize", lambda b: Tx())
-    monkeypatch.setattr("engine.Keypair.from_secret_key", lambda b: object())
+    monkeypatch.setattr("engine.Keypair.from_bytes", lambda b: object())
 
     calls: dict[str, str | bytes] = {}
 

--- a/tests/test_limit_order.py
+++ b/tests/test_limit_order.py
@@ -52,7 +52,7 @@ async def test_limit_order(monkeypatch):
             return b"tx_signed"
 
     monkeypatch.setattr("engine.Transaction.deserialize", lambda b: Tx())
-    monkeypatch.setattr("engine.Keypair.from_secret_key", lambda b: object())
+    monkeypatch.setattr("engine.Keypair.from_bytes", lambda b: object())
 
     class FakeClient:
         def __init__(self, *a, **k):

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -70,7 +70,7 @@ async def test_execute_buy_uses_trades(monkeypatch):
             return b"tx"
 
     monkeypatch.setattr("engine.Transaction.deserialize", lambda b: Tx())
-    monkeypatch.setattr("engine.Keypair.from_secret_key", lambda b: object())
+    monkeypatch.setattr("engine.Keypair.from_bytes", lambda b: object())
     monkeypatch.setattr(
         "engine.Client",
         lambda *a, **k: types.SimpleNamespace(

--- a/tests/test_slippage.py
+++ b/tests/test_slippage.py
@@ -45,7 +45,7 @@ async def test_slippage_hist(monkeypatch):
             return b"tx"
 
     monkeypatch.setattr("engine.Transaction.deserialize", lambda b: Tx())
-    monkeypatch.setattr("engine.Keypair.from_secret_key", lambda b: object())
+    monkeypatch.setattr("engine.Keypair.from_bytes", lambda b: object())
     monkeypatch.setattr(
         "engine.Client",
         lambda *a, **k: types.SimpleNamespace(


### PR DESCRIPTION
## Summary
- use `solders.keypair.Keypair` instead of deprecated `solana.keypair`
- create Keypair via `from_bytes`
- include `solders` dependency
- adjust tests for new API

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`