### PR TITLE
fix: use solders transaction and keypair

### DIFF
--- a/tests/test_engine_mev.py
+++ b/tests/test_engine_mev.py
@@ -6,6 +6,7 @@ import conftest  # noqa:F401
 import pytest
 from engine import CopyEngine
 import types
+from solders.signature import Signature
 
 
 class DummyExec:
@@ -42,14 +43,18 @@ async def test_jito_fallback(monkeypatch):
     monkeypatch.setattr("engine.base58.b58decode", lambda b: b"")
 
     class Tx:
-        def sign(self, *a):
-            pass
+        message = b""
+        signatures: list = []
 
-        def serialize(self):
+        def __bytes__(self):
             return b"tx_signed"
 
-    monkeypatch.setattr("engine.Transaction.deserialize", lambda b: Tx())
-    monkeypatch.setattr("engine.Keypair.from_bytes", lambda b: object())
+    monkeypatch.setattr("engine.Transaction.from_bytes", lambda b: Tx())
+    monkeypatch.setattr("engine.Transaction.populate", lambda msg, sigs: Tx())
+    monkeypatch.setattr(
+        "engine.Keypair.from_bytes",
+        lambda b: types.SimpleNamespace(sign_message=lambda m: Signature.default()),
+    )
 
     calls: dict[str, str | bytes] = {}
 

--- a/tests/test_slippage.py
+++ b/tests/test_slippage.py
@@ -5,6 +5,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import conftest  # noqa: F401
 import types
 import base64
+from solders.signature import Signature
 import pytest
 from engine import CopyEngine
 
@@ -38,14 +39,18 @@ async def test_slippage_hist(monkeypatch):
     monkeypatch.setattr("engine.base58.b58decode", lambda b: b"")
 
     class Tx:
-        def sign(self, *a):
-            pass
+        message = b""
+        signatures: list = []
 
-        def serialize(self):
+        def __bytes__(self):
             return b"tx"
 
-    monkeypatch.setattr("engine.Transaction.deserialize", lambda b: Tx())
-    monkeypatch.setattr("engine.Keypair.from_bytes", lambda b: object())
+    monkeypatch.setattr("engine.Transaction.from_bytes", lambda b: Tx())
+    monkeypatch.setattr("engine.Transaction.populate", lambda msg, sigs: Tx())
+    monkeypatch.setattr(
+        "engine.Keypair.from_bytes",
+        lambda b: types.SimpleNamespace(sign_message=lambda m: Signature.default()),
+    )
     monkeypatch.setattr(
         "engine.Client",
         lambda *a, **k: types.SimpleNamespace(


### PR DESCRIPTION
## Summary
- update imports for solders packages
- adjust tx handling to VersionedTransaction
- update tests for new transaction API

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`
