### PR TITLE
Integrate GMGN Cooperation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Open-source Solana copy trading bot with safety checks and adaptive sizing.
 
+The engine now uses the **GMGN Cooperation‑API** to fetch swap routes and submit
+transactions via HTTP rather than the WebSocket interface.
+
 ## Installation
 
 ```bash

--- a/config.py
+++ b/config.py
@@ -15,6 +15,7 @@ MAX_KELLY_F = float(os.getenv("MAX_KELLY_F", 0.25))
 ATR_LOOKBACK_MIN = int(os.getenv("ATR_LOOKBACK_MIN", 1440))
 PRUNE_INTERVAL_H = float(os.getenv("PRUNE_INTERVAL_H", 6))
 JUPITER_URL = "https://quote-api.jup.ag"
+COOP_URL = "https://gmgn.ai"
 PYTH_HIST_URL = "https://hermes.pyth.network/api/historical_price/"
 RPC_URL = os.getenv("RPC_URL", "https://api.mainnet-beta.solana.com")
 JITO_RPC = os.getenv("JITO_RPC", "")

--- a/tests/test_coop_exec.py
+++ b/tests/test_coop_exec.py
@@ -1,0 +1,61 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import conftest  # noqa:F401
+import pytest
+
+from exec import JupiterExec
+
+
+@pytest.mark.asyncio
+async def test_coop_quote_and_submit(monkeypatch):
+    j = JupiterExec()
+
+    def fake_get(url, params=None):
+        class Resp:
+            async def json(self):
+                return {
+                    "data": {
+                        "quote": {"outAmount": 10},
+                        "raw_tx": {"swapTransaction": "abc"},
+                    }
+                }
+
+            def raise_for_status(self):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                pass
+
+        return Resp()
+
+    monkeypatch.setattr(j.http, "get", fake_get)
+
+    res = await j.quote("A", "B", 1)
+    assert res["data"]
+    tx = await j.swap_tx(res["data"][0])
+    assert tx == "abc"
+
+    def fake_post(url, json=None):
+        class Resp:
+            async def json(self):
+                return {"code": 0, "data": {"hash": "sig"}}
+
+            def raise_for_status(self):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                pass
+
+        return Resp()
+
+    monkeypatch.setattr(j.http, "post", fake_post)
+    resp = await j.submit_tx("abc", anti_mev=True)
+    assert resp["code"] == 0


### PR DESCRIPTION
## Summary
- support GMGN Cooperation API routes
- add constants for the new base URL
- document Cooperation API usage in the README
- test new quote and submission helpers

## Testing
- `black --check exec.py tests/test_coop_exec.py config.py`
- `ruff check .`
- `mypy .`
- `pytest -q`
