### PR TITLE
Enable caching for Flipside queries

### DIFF
--- a/flipside_wallet_bot.py
+++ b/flipside_wallet_bot.py
@@ -24,7 +24,14 @@ def _trending_wallets(limit: int = 10) -> list[str]:
       SUM(pnl) DESC
     LIMIT {limit}
     """
-    res = client.query(sql, page_number=1, page_size=limit)
+    res = client.query(
+        sql,
+        max_age_minutes=60,
+        cached=True,
+        page_number=1,
+        page_size=limit,
+        timeout_minutes=2,
+    )
     return [r[0] for r in (res.records or [])]
 
 

--- a/wallet.py
+++ b/wallet.py
@@ -59,7 +59,10 @@ class FlipsideAPI:  # minimal wrapper over official SDK
     async def _query(self, sql: str, *, max_age_minutes: int = 60):
         """Run a blocking SDK query in a thread."""
         return await asyncio.to_thread(
-            self.client.query, sql, max_age_minutes=max_age_minutes
+            self.client.query,
+            sql,
+            max_age_minutes=max_age_minutes,
+            cached=True,
         )
 
     async def info(self, addr: str, tf: str = "30d"):


### PR DESCRIPTION
## Summary
- ensure trending wallet fetch uses query options
- enable cached Flipside queries

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`
