### PR TITLE
Fix Flipside column names

### DIFF
--- a/flipside_wallet_bot.py
+++ b/flipside_wallet_bot.py
@@ -9,11 +9,15 @@ from config import FLIPSIDE_API_KEY, FLIPSIDE_API_URL
 
 
 def _trending_wallets(limit: int = 10) -> list[str]:
-    """Return top wallets ranked by 30-day PnL using the public tables."""
+    """Return top wallets ranked by 30-day PnL.
+
+    Uses ``solana.core.fact_transactions`` and the ``signer`` and ``pnl``
+    columns documented in Flipside's public tables.
+    """
     client = Flipside(FLIPSIDE_API_KEY, FLIPSIDE_API_URL)
     sql = f"""
     SELECT
-      wallet_address AS address
+      signer AS address
     FROM
       solana.core.fact_transactions
     WHERE


### PR DESCRIPTION
## Summary
- query Flipside using the `signer` column in trending wallet lookup
- use `signer` instead of `wallet_address` for wallet info and trades
- document which Flipside table/columns are queried

## Testing
- `black flipside_wallet_bot.py wallet.py`
- `ruff check flipside_wallet_bot.py wallet.py`
- `mypy flipside_wallet_bot.py wallet.py`
- `pytest -q`