### PR TITLE
Improve trade handling and trending wallet query

### DIFF
--- a/flipside_wallet_bot.py
+++ b/flipside_wallet_bot.py
@@ -13,13 +13,13 @@ from config import FLIPSIDE_API_KEY, FLIPSIDE_API_URL
 def _trending_wallets(limit: int = 10) -> list[str]:
     """Return top wallets ranked by 30-day PnL.
 
-    Uses ``solana.core.fact_transactions`` and the ``signer_address`` and ``pnl``
+    Uses ``solana.core.fact_transactions`` and the ``signer`` and ``pnl``
     columns documented in Flipside's public tables.
     """
     client = Flipside(FLIPSIDE_API_KEY, FLIPSIDE_API_URL)
     sql = f"""
       SELECT
-        signer_address AS address
+        signer AS address
     FROM
       solana.core.fact_transactions
     WHERE

--- a/tests/test_flipside_wallet_bot.py
+++ b/tests/test_flipside_wallet_bot.py
@@ -3,8 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import conftest  # noqa:F401
-import types
-import pytest
+
 
 import flipside_wallet_bot as fwb
 from flipside.errors import QueryRunExecutionError


### PR DESCRIPTION
## Summary
- fix Notifier to close aiohttp session properly
- skip trade execution when calculated size is < 1 token
- use correct `signer` column in trending wallet query
- clean up unused imports in tests

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`